### PR TITLE
Adapt Mung Parser to Handle Other Datasets

### DIFF
--- a/mung/io.py
+++ b/mung/io.py
@@ -250,18 +250,10 @@ def read_nodes_from_file(filename: str) -> List[Node]:
     root = tree.getroot()
     logging.debug('XML parsed.')
     nodes = []
-    dataset = 'Unknown'
 
-    if 'dataset' in root.attrib:
-        dataset = root.attrib['dataset']
-    document = 'Unknown'
-
-    if 'document' in root.attrib:
-        document = root.attrib['document']
-    node_tag = 'Node'
-
-    if not list(root.iter(node_tag)):
-        node_tag = 'CropObject'
+    dataset = root.attrib.get('dataset', 'Unknown')
+    document = root.attrib.get('document', 'Unknown')
+    node_tag = 'Node' if list(root.iter('Node')) else 'CropObject'
 
     for i, node in enumerate(root.iter(node_tag)):
         ######################################################

--- a/mung/io.py
+++ b/mung/io.py
@@ -250,10 +250,20 @@ def read_nodes_from_file(filename: str) -> List[Node]:
     root = tree.getroot()
     logging.debug('XML parsed.')
     nodes = []
-    dataset = root.attrib['dataset']
-    document = root.attrib['document']
+    dataset = 'Unknown'
 
-    for i, node in enumerate(root.iter('Node')):
+    if 'dataset' in root.attrib:
+        dataset = root.attrib['dataset']
+    document = 'Unknown'
+
+    if 'document' in root.attrib:
+        document = root.attrib['document']
+    node_tag = 'Node'
+
+    if not list(root.iter(node_tag)):
+        node_tag = 'CropObject'
+
+    for i, node in enumerate(root.iter(node_tag)):
         ######################################################
         logging.debug('Parsing Node {0}'.format(i))
 

--- a/mung/node.py
+++ b/mung/node.py
@@ -813,7 +813,7 @@ class Node(object):
         mask_flat = numpy.zeros(shape[0]*shape[1], numpy.uint8)
         index = 0
 
-        mask_string = mask_string.strip().rstrip()
+        mask_string = mask_string.rstrip()
 
         for kv in mask_string.split(' '):
             k_string, v_string = kv.split(':')

--- a/mung/node.py
+++ b/mung/node.py
@@ -812,6 +812,9 @@ class Node(object):
 
         mask_flat = numpy.zeros(shape[0]*shape[1], numpy.uint8)
         index = 0
+
+        mask_string = mask_string.strip().rstrip()
+
         for kv in mask_string.split(' '):
             k_string, v_string = kv.split(':')
             k, v = int(k_string), int(v_string)


### PR DESCRIPTION
# Adapt Mung Parser to Handle Other Datasets

## Description:
This update modifies the mung parser to support the DoReMi and Musigraph datasets.

## Changes:
Adapted io.py and node.py to correctly process XML files from the DoReMi and Musigraph datasets.

### Issues Addressed:
- The DoReMi and Musigraph dataset XML files do not contain the same meta-information as Muscima-pp (missing 'dataset' and 'document' tags).
- Musigraph files use the 'CropObject' node tag (similarly to the first version of Muscima-pp).
- DoReMi object masks end with a trailing whitespace.

## References:
[DoReMi Dataset](https://elonashatri.github.io/doremi-dataset.html)
[Musigraph Dataset](https://pages.cvc.uab.es/abaro/datasets.html)